### PR TITLE
I'm unable to publish

### DIFF
--- a/src/utils/packages.js
+++ b/src/utils/packages.js
@@ -5,9 +5,13 @@ import getNpmTarballUrl from 'get-npm-tarball-url'
 import semver from 'semver'
 
 export async function extractPackageJSON (buffer) {
+  console.log(`ext-1`, buffer);
   const blob = new Blob([Buffer.from(buffer)])
+  console.log(`ext-2`);
   const stream = blob.stream().pipeThrough(new DecompressionStream('gzip'))
+  console.log(`ext-3`);
   for await (const obj of extract(stream)) {
+    console.log(`ext-3.1`, obj.header.name);
     if (obj.header.name === 'package/package.json') {
       return JSON.parse(await obj.text())
     }


### PR DESCRIPTION
I run vsr per 'npm run dev'. 
First I got some SQL constraints problems which I solved by introducing a mergeTags function.  I hopefully found the tonality of the project-source code.
Second I run into the problem that extractPackageJSON is not able to extract published tarball. The loop:
```
for await (const obj of extract(stream))  {
   ....
}
```
only extracts the first file and than:
```
ext-3.1 package/index.cjs
✘ [ERROR] A hanging Promise was canceled. This happens when the worker runtime is waiting for a Promise from JavaScript to resolve, but has detected that the Promise cannot possibly ever resolve because all code and events related to the Promise's I/O context have already finished.
```
I don't understand why for now --- any help?
It looks like that streaming-tarball has some issues.
